### PR TITLE
Make Project Page Static

### DIFF
--- a/app/projects/[...slug]/page.tsx
+++ b/app/projects/[...slug]/page.tsx
@@ -4,6 +4,10 @@ import ProjectLayout from '@/layouts/ProjectLayout'
 import { coreContent } from 'pliny/utils/contentlayer'
 import { notFound } from 'next/navigation'
 
+export const generateStaticParams = async () => {
+  return allProjects.map((p) => ({ slug: p.slug.split('/').map((name) => decodeURI(name)) }))
+}
+
 export default async function Page(props: { params: Promise<{ slug: string[] }> }) {
   const params = await props.params
   const slug = decodeURI(params.slug.join('/'))

--- a/data/blog/projects/godot/tomato-man/01-expectation-management.mdx
+++ b/data/blog/projects/godot/tomato-man/01-expectation-management.mdx
@@ -7,6 +7,8 @@ layout: PostLayoutReduced
 canonicalUrl:
 ---
 
+<TOCInline toc={props.toc} asDisclosure toHeading={3} />
+
 Ok, now for some expectations for those of you who have decided to continue enduring my lunacy:
 
 - My motivation is scarce, so prepare your heart
@@ -55,6 +57,8 @@ and a couple of hazards, such as spikes and springboards. Also, naturally, (and 
 made music specifically for this art pack) some music and sound effects. There's also a parallax background provided,
 so that'd be nice to throw in there. Finally, the main character will be able to double-jump, slide, pick up and throw
 boxes, climb ladders, punch the enemies, and all the other usual platformer things.
+
+### Blog
 
 Regarding the blog itself, the intent is to write about higher-level concepts, such as decisions, learnings, and maybe
 even some why's. This is an attempt to further grow my ability to think through things and explain them. I'm sure the

--- a/layouts/PostLayoutReduced.tsx
+++ b/layouts/PostLayoutReduced.tsx
@@ -75,18 +75,6 @@ export default function PostLayoutReduced({ content, next, prev, children }: Lay
                 )}
                 {(next || prev) && (
                   <div className="flex justify-between py-4 xl:block xl:space-y-8 xl:py-8">
-                    {prev && prev.path && (
-                      <div>
-                        <h2 className="text-xs tracking-wide text-gray-500 uppercase dark:text-gray-400">
-                          Previous Article
-                        </h2>
-                        <div className="text-primary-500 hover:text-primary-600 dark:hover:text-primary-400">
-                          <Link href={`/${prev.path}`} data-cy="previous-article-link">
-                            {prev.title}
-                          </Link>
-                        </div>
-                      </div>
-                    )}
                     {next && next.path && (
                       <div>
                         <h2 className="text-xs tracking-wide text-gray-500 uppercase dark:text-gray-400">
@@ -95,6 +83,18 @@ export default function PostLayoutReduced({ content, next, prev, children }: Lay
                         <div className="text-primary-500 hover:text-primary-600 dark:hover:text-primary-400">
                           <Link href={`/${next.path}`} data-cy="next-article-link">
                             {next.title}
+                          </Link>
+                        </div>
+                      </div>
+                    )}
+                    {prev && prev.path && (
+                      <div>
+                        <h2 className="text-xs tracking-wide text-gray-500 uppercase dark:text-gray-400">
+                          Previous Article
+                        </h2>
+                        <div className="text-primary-500 hover:text-primary-600 dark:hover:text-primary-400">
+                          <Link href={`/${prev.path}`} data-cy="previous-article-link">
+                            {prev.title}
                           </Link>
                         </div>
                       </div>


### PR DESCRIPTION
This also adds a table of contents to the Expectations Management article, and swaps the positions of the next and previous article links within articles.

Resolves #63 